### PR TITLE
Encode the string before generating the URL

### DIFF
--- a/js/jquery.tweetit.js
+++ b/js/jquery.tweetit.js
@@ -102,7 +102,10 @@
 				$("#tweetit-start").remove();
 				$("#tweetit-end").remove();
 				var shift = "+=10";
-			
+
+				//Encode the URL
+				sel = encodeURIComponent(sel);
+				
 				mainUrl = mainUrl.replace('{0}', sel.toString().substring(0, chars - 4));
 
 				$("body").append($btn.attr('href', mainUrl));


### PR DESCRIPTION
Escapes all characters like & / \ +